### PR TITLE
Tweak Class Responsibility of Compiler vs. Loader, improving separation of concerns

### DIFF
--- a/utemplate/source.py
+++ b/utemplate/source.py
@@ -58,7 +58,7 @@ class Compiler:
                 self.args = ""
         elif tokens[0] == "include":
             tokens = tokens[1].split(None, 1)
-            with open(self.loader.file_path(tokens[0][1:-1])) as inc:
+            with self.loader.file_open(tokens[0][1:-1]) as inc:
                 self.seq += 1
                 c = Compiler(inc, self.file_out, len(self.stack) + self._indent, self.seq)
                 inc_id = self.seq
@@ -154,6 +154,9 @@ class Loader(compiled.Loader):
 
     def file_path(self, template):
         return self.pkg_path + self.dir + "/" + template
+    
+    def file_open(self, template):
+        return open(self.file_path(template))
 
     def compiled_path(self, template):
         return self.dir + "/compiled/" + template.replace(".", "_") + ".py"


### PR DESCRIPTION
This tweak to the way Compiler hands off to Loader allows me to create a duck-typed 'Loader' which satisfies the duck-typing required for Compiler to do its work, even when the backing data store for uncompiled templates is not actually a filesystem available through 'open'. The change avoids the stream io API in use leaking into the Compiler logic.

I have found myself needing to do this for the specialisation of tiny template fragments (authored by non-coders directly through object constructors, hence the value of the Jinja2 syntax) to be rendered to a 160 character screen. 

The size of the templates allows them to be stored as strings in dicts, which is very convenient for the authors, and thanks to the strategy you've demonstrated, I can in the future construct logic to compile them into the ESP8266 frozen filesystem if needed for optimisation, but they certainly won't be authored that way.

Even for this toy case, ```{% include 'name' %} ``` is a really useful directive, though, so this tweak gives me the best of both worlds and would mean I can depend directly on utemplate, rather than my own diverged version.

The use is demonstrated by this test example...
https://github.com/cefn/utemplate/blob/resolver_gist/resolver_gist.py
...but also the evolving stories using our api which ape the kind of logic used in [Twine](https://github.com/tweecode/twine) but for a network of RFID enabled, boot-to-micropython boxes with minimal screens intended to be backed by utemplate and with template fragments existing as properties on objects, not files in folders...
https://github.com/cefn/avatap/blob/master/python/stories/corbridge.py